### PR TITLE
Add feature to check line numbers for missing numbers or out of sequence numbers via branch check_for_no_line_number

### DIFF
--- a/src/debug_tokenize/debug_tokenize.py
+++ b/src/debug_tokenize/debug_tokenize.py
@@ -143,7 +143,8 @@ def check_line_number_seq(lines_list):
         None: implicit return
     """
 
-    ln_num_buffer = [0]
+    line_no = 0;  # handles case where first line does not have a line number
+    ln_num_buffer = [0];  # first popped after three line numbers are appended
     for line in lines_list:
         try:
             (line_no, line_str) = split_line_num(line)

--- a/src/debug_tokenize/debug_tokenize.py
+++ b/src/debug_tokenize/debug_tokenize.py
@@ -132,24 +132,37 @@ def write_binary(filename, int_list):
             file.write(byte.to_bytes(1, byteorder='big'))
 
 
-def check_for_line_numbers(lines_list):
-    line_no_buffer = []
+def check_line_number_seq(lines_list):
+    """Check each line in the program that either does not start with a line
+       number or starts with an out of sequence line number.
+
+    Args:
+        lines_list (list): List of lines (str) in program.
+
+    Returns:
+        None: implicit return
+    """
+
+    ln_num_buffer = [0]
     for line in lines_list:
         try:
             (line_no, line_str) = split_line_num(line)
-            line_no_buffer.append(line_no)
-            if len(line_no_buffer) < 3:
+            ln_num_buffer.append(line_no)
+            if len(ln_num_buffer) < 4:
                 continue
-            if line_no_buffer[1] <= line_no_buffer[0] or\
-               line_no_buffer[1] >= line_no_buffer[2]:
-                print(f"Entry error after line {line_no_buffer[1]} - lines "
-                      "shoud be in sequential order. Exiting.")
+            ln_num_buffer.pop(0)
+
+            if not ln_num_buffer[0] <= ln_num_buffer[1] <= ln_num_buffer[2]:
+                print("Entry error one or two lines after line "
+                      f"{ln_num_buffer[0]} - lines should be in sequential "
+                      "order.  Exiting.")
                 sys.exit(1)
-            line_no_buffer.pop(0)
+
         except ValueError:
             print(f"Entry error after line {line_no} - each line should start "
                   "with a line number. Exiting.")
             sys.exit(1)
+
 
 # convert ahoy special characters to petcat special characters
 def ahoy_lines_list(lines_list, char_maps):
@@ -411,7 +424,7 @@ def main(argv=None):
         sys.exit(1)
 
     # check each line to insure each starts with a line number
-    check_for_line_numbers(lines_list)
+    check_line_number_seq(lines_list)
 
     # convert to petcat format and write petcat-ready file
     if args.source[0][:4] == 'ahoy':

--- a/src/debug_tokenize/debug_tokenize.py
+++ b/src/debug_tokenize/debug_tokenize.py
@@ -160,7 +160,7 @@ def check_line_number_seq(lines_list):
 
         except ValueError:
             print(f"Entry error after line {line_no} - each line should start "
-                  "with a line number. Exiting.")
+                  "with a line number.  Exiting.")
             sys.exit(1)
 
 

--- a/src/debug_tokenize/debug_tokenize.py
+++ b/src/debug_tokenize/debug_tokenize.py
@@ -33,7 +33,7 @@ def parse_args(argv):
         "Commodore key as follows:\n\n"
         "    - Underlined characters - preceed entry with Shift key\n"
         "    - Overlined characters - preceed entry with Commodore key\n\n"
-        "Standard keyboard letters should be typed as follows for these " 
+        "Standard keyboard letters should be typed as follows for these "
         "two cases.\n"
         "    -{SHIFT-A}, {SHIFT-B}, {SHIFT-*} etc.\n"
         "    -{C=-A}, {C=-B}, {C=-*}, etc.\n\n"
@@ -143,11 +143,11 @@ def check_line_number_seq(lines_list):
         None: implicit return
     """
 
-    line_no = 0;  # handles case where first line does not have a line number
-    ln_num_buffer = [0];  # first popped after three line numbers are appended
+    line_no = 0  # handles case where first line does not have a line number
+    ln_num_buffer = [0]  # first popped after three line numbers are appended
     for line in lines_list:
         try:
-            (line_no, line_str) = split_line_num(line)
+            line_no = split_line_num(line)[0]
             ln_num_buffer.append(line_no)
             if len(ln_num_buffer) < 4:
                 continue
@@ -165,8 +165,19 @@ def check_line_number_seq(lines_list):
             sys.exit(1)
 
 
-# convert ahoy special characters to petcat special characters
 def ahoy_lines_list(lines_list, char_maps):
+    """For each line in the program, convert Ahoy special characters to Petcat
+       special characters.
+
+    Args:
+        lines_list (list): List of lines (str) in program.
+        char_maps (module): Module containing conversion maps between various
+                            Commodore and magazine formats.
+
+    Returns:
+        new_lines (list): List of new lines (str) after special characters are
+                            converted from Ahoy to petcat format.
+    """
 
     new_lines = []
 
@@ -200,7 +211,7 @@ def ahoy_lines_list(lines_list, char_maps):
             new_line = []
 
             # piece the string segments and petcat codes back together
-            for count, segment in enumerate(new_codes):
+            for count in range(len(new_codes)):
                 new_line.append(str_split[count])
                 new_line.append(new_codes[count])
         # handle case where line contained no special characters
@@ -258,6 +269,8 @@ def scan(ln, char_maps, tokenize=True):
 
     Args:
         ln (str): Text of each line segment to parse and convert
+        char_maps (module): Module containing conversion maps between various
+                            Commodore and magazine formats.
         tokenize (bool): Flag to indicate if start of line segment should be
             tokenized (False if line segment start is within quotes or after
             a REM statement)
@@ -304,9 +317,8 @@ def check_overwrite(filename):
                           'Overwrite? (Y = yes) ')
     if overwrite.lower() == 'y':
         return True
-    else:
-        print('File not overwritten - exiting.')
-        sys.exit(1)
+    print('File not overwritten - exiting.')
+    sys.exit(1)
 
 
 def ahoy1_checksum(byte_list):

--- a/src/debug_tokenize/debug_tokenize.py
+++ b/src/debug_tokenize/debug_tokenize.py
@@ -132,6 +132,25 @@ def write_binary(filename, int_list):
             file.write(byte.to_bytes(1, byteorder='big'))
 
 
+def check_for_line_numbers(lines_list):
+    line_no_buffer = []
+    for line in lines_list:
+        try:
+            (line_no, line_str) = split_line_num(line)
+            line_no_buffer.append(line_no)
+            if len(line_no_buffer) < 3:
+                continue
+            if line_no_buffer[1] <= line_no_buffer[0] or\
+               line_no_buffer[1] >= line_no_buffer[2]:
+                print(f"Entry error after line {line_no_buffer[1]} - lines "
+                      "shoud be in sequential order. Exiting.")
+                sys.exit(1)
+            line_no_buffer.pop(0)
+        except ValueError:
+            print(f"Entry error after line {line_no} - each line should start "
+                  "with a line number. Exiting.")
+            sys.exit(1)
+
 # convert ahoy special characters to petcat special characters
 def ahoy_lines_list(lines_list, char_maps):
 
@@ -390,6 +409,9 @@ def main(argv=None):
     except IOError:
         print("File read failed - please check source file name and path.")
         sys.exit(1)
+
+    # check each line to insure each starts with a line number
+    check_for_line_numbers(lines_list)
 
     # convert to petcat format and write petcat-ready file
     if args.source[0][:4] == 'ahoy':

--- a/tests/debug_tokenize_test.py
+++ b/tests/debug_tokenize_test.py
@@ -59,21 +59,49 @@ def test_read_file(infile_data):
 
 
 @pytest.mark.parametrize(
-    "lines_list, term_capture, err_capture",
+    "lines_list, term_capture",
     [
-        (["10 OK", "20 OK", "5 OFF", "40 OK"],
-         "Entry error one or two lines after line 10 - lines should be in sequential order.  Exiting.\n",
-         "SystemExit"),
-        (["10 OK", "200 OFF", "30 OK", "40 OK"],
-         "Entry error one or two lines after line 10 - lines should be in sequential order.  Exiting.\n",
-         "SystemExit"),
+        (["10 OK", "20 OK", "30 OK", "40 OK"],
+         ""
+         ),
     ],
 )
-def test_check_line_number_seq(capsys, lines_list, term_capture, err_capture):
+def test_check_line_number_seq_a(capsys, lines_list, term_capture):
     """
     Unit test to check that function check_line_number_seq() is propery
     identifying cases where lines either don't start with an integer line
     number or have line numbers out of sequence.
+    """
+    check_line_number_seq(lines_list)
+    out, err = capsys.readouterr()
+    assert out == term_capture
+
+
+@pytest.mark.parametrize(
+    "lines_list, term_capture",
+    [
+        (["10 OK", "20 OK", "5 OFF", "40 OK"],
+         "Entry error one or two lines after line 10 - lines should be in "
+         "sequential order.  Exiting.\n"
+         ),
+        (["10 OK", "200 OFF", "30 OK", "40 OK"],
+         "Entry error one or two lines after line 10 - lines should be in "
+         "sequential order.  Exiting.\n"
+         ),
+        (["10 OK", "200 OFF", "3 OFF", "40 OK"],
+         "Entry error one or two lines after line 10 - lines should be in "
+         "sequential order.  Exiting.\n"
+         ),
+        (["10 OK", "OFF", "30 OK", "40 OK"],
+         "Entry error after line 10 - each line should start with a line "
+         "number.  Exiting.\n"
+         ),
+    ],
+)
+def test_check_line_number_seq_b(capsys, lines_list, term_capture):
+    """
+    Unit test to check that function check_line_number_seq() is propery
+    identifying cases where lines have the correct line number sequencing.
     """
     with pytest.raises(SystemExit):
         check_line_number_seq(lines_list)

--- a/tests/debug_tokenize_test.py
+++ b/tests/debug_tokenize_test.py
@@ -318,4 +318,3 @@ def test_print_checksums(capsys, ahoy_checksums, term_width, term_capture):
     print_checksums(ahoy_checksums, term_width)
     captured = capsys.readouterr()
     assert captured.out == term_capture
-

--- a/tests/debug_tokenize_test.py
+++ b/tests/debug_tokenize_test.py
@@ -3,6 +3,7 @@ import pytest
 
 from debug_tokenize.debug_tokenize import parse_args, \
                                           read_file, \
+                                          check_line_number_seq, \
                                           ahoy_lines_list, \
                                           split_line_num, \
                                           scan, \
@@ -55,6 +56,29 @@ def test_read_file(infile_data):
     a file source.
     """
     assert infile_data == ['10 print"hello!"', '20 goto10']
+
+
+@pytest.mark.parametrize(
+    "lines_list, term_capture, err_capture",
+    [
+        (["10 OK", "20 OK", "5 OFF", "40 OK"],
+         "Entry error one or two lines after line 10 - lines should be in sequential order.  Exiting.\n",
+         "SystemExit"),
+        (["10 OK", "200 OFF", "30 OK", "40 OK"],
+         "Entry error one or two lines after line 10 - lines should be in sequential order.  Exiting.\n",
+         "SystemExit"),
+    ],
+)
+def test_check_line_number_seq(capsys, lines_list, term_capture, err_capture):
+    """
+    Unit test to check that function check_line_number_seq() is propery
+    identifying cases where lines either don't start with an integer line
+    number or have line numbers out of sequence.
+    """
+    with pytest.raises(SystemExit):
+        check_line_number_seq(lines_list)
+    out, err = capsys.readouterr()
+    assert out == term_capture
 
 
 @pytest.mark.parametrize(

--- a/tests/debug_tokenize_test.py
+++ b/tests/debug_tokenize_test.py
@@ -69,12 +69,11 @@ def test_read_file(infile_data):
 def test_check_line_number_seq_a(capsys, lines_list, term_capture):
     """
     Unit test to check that function check_line_number_seq() is propery
-    identifying cases where lines either don't start with an integer line
-    number or have line numbers out of sequence.
+    identifying cases where lines have the correct line number sequencing.
     """
     check_line_number_seq(lines_list)
-    out, err = capsys.readouterr()
-    assert out == term_capture
+    capture = capsys.readouterr()
+    assert capture.out == term_capture
 
 
 @pytest.mark.parametrize(
@@ -92,8 +91,16 @@ def test_check_line_number_seq_a(capsys, lines_list, term_capture):
          "Entry error one or two lines after line 10 - lines should be in "
          "sequential order.  Exiting.\n"
          ),
+        (["100 OFF", "20 OK", "30 OK", "40 OK"],
+         "Entry error one or two lines after line 100 - lines should be in "
+         "sequential order.  Exiting.\n"
+         ),
         (["10 OK", "OFF", "30 OK", "40 OK"],
          "Entry error after line 10 - each line should start with a line "
+         "number.  Exiting.\n"
+         ),
+        (["OFF", "20OK", "30 ON", "40 OK"],
+         "Entry error after line 0 - each line should start with a line "
          "number.  Exiting.\n"
          ),
     ],
@@ -101,12 +108,13 @@ def test_check_line_number_seq_a(capsys, lines_list, term_capture):
 def test_check_line_number_seq_b(capsys, lines_list, term_capture):
     """
     Unit test to check that function check_line_number_seq() is propery
-    identifying cases where lines have the correct line number sequencing.
+    identifying cases where lines either don't start with an integer line
+    number or have line numbers out of sequence.
     """
     with pytest.raises(SystemExit):
         check_line_number_seq(lines_list)
-    out, err = capsys.readouterr()
-    assert out == term_capture
+    capture = capsys.readouterr()
+    assert capture.out == term_capture
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Incorporate feature branch that adds support for 1) checking for valid line numbers and for 2) checking for sequential line numbers in the typed in programs and adds unit tests for both cases. Fixes a few other linting issues also.  
Fixes #11 