### PR TITLE
Bug repellent 3

### DIFF
--- a/src/debug_tokenize/debug_tokenize.py
+++ b/src/debug_tokenize/debug_tokenize.py
@@ -400,6 +400,58 @@ def ahoy2_checksum(byte_list):
     return checksum
 
 
+def ahoy3_checksum(byte_list):
+    '''
+    Function to create Ahoy checksums from passed in byte list to match the
+    codes printed in the magazine to check each line for typed in accuracy.
+    Covers Ahoy Bug Repellent version for May 1984-Apr 1987 issues.
+    '''
+
+    xor_value = 0
+    char_position = 1
+    carry_flag = 1
+    in_quotes = False
+
+    for char_val in byte_list:
+
+        # set carry flag to zero for char values less than ascii value for
+        # quote character since assembly code for repellent sets carry flag
+        # based on cmp 0x22 (decimal 34)
+        if char_val < 34:
+            carry_flag = 0
+        else:
+            carry_flag = 1
+
+        # Detect quote symbol in line and toggle in-quotes flag
+        if char_val == 34:
+            in_quotes = not in_quotes
+
+        # Detect spaces that are outside of quotes and ignore them, else
+        # execute primary checksum generation algorithm
+        if char_val == 32 and in_quotes is False:
+            continue
+        else:
+            next_value = char_val + xor_value + carry_flag
+
+            xor_value = next_value ^ char_position
+
+            # limit next value to fit in one byte
+            next_value = next_value & 255
+
+            char_position = char_position + 1
+
+    # get high nibble of xor_value
+    high_nib = (xor_value & 0xf0) >> 4
+    high_char_val = high_nib + 65  # 0x41
+    # high_char_val = high_char_val & 0x0f
+    # get low nibble of xor_value
+    low_nib = xor_value & 0x0f
+    low_char_val = low_nib + 65  # 0x41
+    # low_char_val = low_char_val & 0x0f
+    checksum = chr(high_char_val) + chr(low_char_val)
+    return checksum
+
+
 def print_checksums(ahoy_checksums, terminal_width):
 
     # Determine number of columns to print based on terminal window width

--- a/src/debug_tokenize/debug_tokenize.py
+++ b/src/debug_tokenize/debug_tokenize.py
@@ -74,11 +74,13 @@ def parse_args(argv):
     )
 
     parser.add_argument(
-        "-s", "--source", choices=["ahoy1", "ahoy2"], type=str, nargs=1,
+        "-s", "--source", choices=["ahoy1", "ahoy2", "ahoy4"], type=str, nargs=1,
         required=False, metavar="source_format", default=["ahoy2"],
         help="Specifies the magazine source for conversion and checksum:\n"
              "ahoy1 - Ahoy magazine (Apr-May 1984)\n"
-             "ahoy2 - Ahoy magazine (Jun 1984-Apr 1987) (default)\n"
+             "ahoy2 - Ahoy magazine (Jun 1984-Oct 1984) (default)\n"
+             "ahoy3 - Ahoy magazine (Nov 1984-Apr 1987)) - not implemented\n"
+             "ahoy4 - Ahoy magazine (May 1987-))\n"
     )
 
     parser.add_argument(
@@ -400,7 +402,7 @@ def ahoy2_checksum(byte_list):
     return checksum
 
 
-def ahoy3_checksum(line_num, byte_list):
+def ahoy4_checksum(line_num, byte_list):
     '''
     Function to create Ahoy checksums from passed in line number and byte list
     to match the codes printed in the magazine to check each line for typed in
@@ -414,8 +416,10 @@ def ahoy3_checksum(line_num, byte_list):
     line_low = line_num % 256
     line_hi = int(line_num / 256)
 
-    byte_list.insert(0, line_hi)
-    byte_list.insert(0, line_low)
+    byte_list = [line_low] + [line_hi] + byte_list
+
+    # byte_list.insert(0, line_hi)
+    # byte_list.insert(0, line_low)
 
     for char_val in byte_list:
 
@@ -536,8 +540,8 @@ def main(argv=None):
             ahoy_checksums.append((line_num, ahoy1_checksum(byte_list)))
         elif args.source[0] == 'ahoy2':
             ahoy_checksums.append((line_num, ahoy2_checksum(byte_list)))
-        elif args.source[0] == 'ahoy3':
-            ahoy_checksums.append((line_num, ahoy3_checksum(line_num, byte_list)))
+        elif args.source[0] == 'ahoy4':
+            ahoy_checksums.append((line_num, ahoy4_checksum(line_num, byte_list)))
         else:
             print("Magazine format not yet supported.")
             sys.exit(1)

--- a/src/debug_tokenize/debug_tokenize.py
+++ b/src/debug_tokenize/debug_tokenize.py
@@ -408,19 +408,10 @@ def ahoy3_checksum(byte_list):
     '''
 
     xor_value = 0
-    char_position = 1
-    carry_flag = 1
+    char_position = 0
     in_quotes = False
 
     for char_val in byte_list:
-
-        # set carry flag to zero for char values less than ascii value for
-        # quote character since assembly code for repellent sets carry flag
-        # based on cmp 0x22 (decimal 34)
-        if char_val < 34:
-            carry_flag = 0
-        else:
-            carry_flag = 1
 
         # Detect quote symbol in line and toggle in-quotes flag
         if char_val == 34:
@@ -431,7 +422,7 @@ def ahoy3_checksum(byte_list):
         if char_val == 32 and in_quotes is False:
             continue
         else:
-            next_value = char_val + xor_value + carry_flag
+            next_value = char_val + xor_value 
 
             xor_value = next_value ^ char_position
 

--- a/src/debug_tokenize/debug_tokenize.py
+++ b/src/debug_tokenize/debug_tokenize.py
@@ -400,16 +400,22 @@ def ahoy2_checksum(byte_list):
     return checksum
 
 
-def ahoy3_checksum(byte_list):
+def ahoy3_checksum(line_num, byte_list):
     '''
-    Function to create Ahoy checksums from passed in byte list to match the
-    codes printed in the magazine to check each line for typed in accuracy.
-    Covers Ahoy Bug Repellent version for May 1984-Apr 1987 issues.
+    Function to create Ahoy checksums from passed in line number and byte list
+    to match the codes printed in the magazine to check each line for typed in
+    accuracy. Covers the last Ahoy Bug Repellent verion introduced in Apr 1987.
     '''
 
     xor_value = 0
     char_position = 0
     in_quotes = False
+
+    line_low = line_num % 256
+    line_hi = int(line_num / 256)
+
+    byte_list.insert(0, line_hi)
+    byte_list.insert(0, line_low)
 
     for char_val in byte_list:
 
@@ -530,6 +536,8 @@ def main(argv=None):
             ahoy_checksums.append((line_num, ahoy1_checksum(byte_list)))
         elif args.source[0] == 'ahoy2':
             ahoy_checksums.append((line_num, ahoy2_checksum(byte_list)))
+        elif args.source[0] == 'ahoy3':
+            ahoy_checksums.append((line_num, ahoy3_checksum(line_num, byte_list)))
         else:
             print("Magazine format not yet supported.")
             sys.exit(1)

--- a/tests/debug_tokenize_test.py
+++ b/tests/debug_tokenize_test.py
@@ -11,6 +11,7 @@ from debug_tokenize.debug_tokenize import parse_args, \
                                           write_binary, \
                                           ahoy1_checksum, \
                                           ahoy2_checksum, \
+                                          ahoy3_checksum, \
                                           print_checksums
 
 
@@ -293,6 +294,24 @@ def test_ahoy2_checksum(byte_list, checksum):
     """
 
     assert ahoy2_checksum(byte_list) == checksum
+
+
+@pytest.mark.parametrize(
+    "byte_list, checksum",
+    [
+        # '25 GOSUB325'
+        ([25, 0, 141, 51, 50, 53], 'EH'),
+        # '30 GOSUB425'
+        ([30, 0, 141, 52, 50, 53], 'EP'),
+    ],
+)
+def test_ahoy3_checksum(byte_list, checksum):
+    """
+    Unit test to check that function ahoy2_checksum() is properly calculating
+    and returning the proper ahoy checksum code.
+    """
+
+    assert ahoy3_checksum(byte_list) == checksum
 
 
 @pytest.mark.parametrize(

--- a/tests/debug_tokenize_test.py
+++ b/tests/debug_tokenize_test.py
@@ -300,9 +300,9 @@ def test_ahoy2_checksum(byte_list, checksum):
     "byte_list, checksum",
     [
         # '25 GOSUB325'
-        ([25, 0, 141, 51, 50, 53], 'EH'),
+        ([25, 0, 141, 51, 50, 53, 0], 'EH'),
         # '30 GOSUB425'
-        ([30, 0, 141, 52, 50, 53], 'EP'),
+        ([30, 0, 141, 52, 50, 53, 0], 'EP'),
     ],
 )
 def test_ahoy3_checksum(byte_list, checksum):

--- a/tests/debug_tokenize_test.py
+++ b/tests/debug_tokenize_test.py
@@ -11,7 +11,7 @@ from debug_tokenize.debug_tokenize import parse_args, \
                                           write_binary, \
                                           ahoy1_checksum, \
                                           ahoy2_checksum, \
-                                          ahoy3_checksum, \
+                                          ahoy4_checksum, \
                                           print_checksums
 
 
@@ -307,15 +307,17 @@ def test_ahoy2_checksum(byte_list, checksum):
         (23456, [141, 51, 50, 53, 0], 'BN'),
         # '30 GOSUB425'
         (30, [141, 52, 50, 53, 0], 'EP'),
+        # '485 RETURN'
+        (485, [142, 0], 'HE'),
     ],
 )
-def test_ahoy3_checksum(line_num, byte_list, checksum):
+def test_ahoy4_checksum(line_num, byte_list, checksum):
     """
-    Unit test to check that function ahoy2_checksum() is properly calculating
+    Unit test to check that function ahoy4_checksum() is properly calculating
     and returning the proper ahoy checksum code.
     """
 
-    assert ahoy3_checksum(line_num, byte_list) == checksum
+    assert ahoy4_checksum(line_num, byte_list) == checksum
 
 
 @pytest.mark.parametrize(

--- a/tests/debug_tokenize_test.py
+++ b/tests/debug_tokenize_test.py
@@ -297,21 +297,25 @@ def test_ahoy2_checksum(byte_list, checksum):
 
 
 @pytest.mark.parametrize(
-    "byte_list, checksum",
+    "line_num, byte_list, checksum",
     [
         # '25 GOSUB325'
-        ([25, 0, 141, 51, 50, 53, 0], 'EH'),
+        (25, [141, 51, 50, 53, 0], 'EH'),
+        # '256 GOSUB325'
+        (256, [141, 51, 50, 53, 0], 'CP'),
+        # '23456 GOSUB325'
+        (23456, [141, 51, 50, 53, 0], 'BN'),
         # '30 GOSUB425'
-        ([30, 0, 141, 52, 50, 53, 0], 'EP'),
+        (30, [141, 52, 50, 53, 0], 'EP'),
     ],
 )
-def test_ahoy3_checksum(byte_list, checksum):
+def test_ahoy3_checksum(line_num, byte_list, checksum):
     """
     Unit test to check that function ahoy2_checksum() is properly calculating
     and returning the proper ahoy checksum code.
     """
 
-    assert ahoy3_checksum(byte_list) == checksum
+    assert ahoy3_checksum(line_num, byte_list) == checksum
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This branch adds support for the third version of Ahoy Bug Repellent.  It is invoked by using the source flag 'ahoy4' because there will be an ahoy3 flag required for an additional variation discovered.  